### PR TITLE
added monitortx commands in show and config

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -628,11 +628,11 @@ def load_minigraph():
 
 
 #
-# config monitortx THRESHOLD 40
-# config monitortx POOLING_PERIOD 20
+# config monitor_tx THRESHOLD 40
+# config monitor_tx POOLING_PERIOD 20
 #
 
-@config.command("monitortx")
+@config.command("monitor_tx")
 @click.argument('param', required=True)
 @click.argument('value', required=True)
 def monitortx_set(param, value):

--- a/config/main.py
+++ b/config/main.py
@@ -625,6 +625,29 @@ def load_minigraph():
     click.echo("Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.")
 
 
+
+
+#
+# config monitortx THRESHOLD 40
+# config monitortx POOLING_PERIOD 20
+#
+
+@config.command("monitortx")
+@click.argument('param', required=True)
+@click.argument('value', required=True)
+def monitortx_set(param, value):
+    if param.lower() != 'threshold' and param.lower() != 'pooling_period':
+        click.echo("Please enter valid configurations")
+    else:
+        table_name = "TX_ERROR_CFG"
+        config_db = ConfigDBConnector()
+        config_db.connect()
+        click.echo(param)
+        config_db.set_entry(table_name, param, {"value":value})
+
+
+
+
 #
 # 'hostname' command
 #

--- a/show/main.py
+++ b/show/main.py
@@ -806,6 +806,34 @@ def status(interfacename, verbose):
     run_command(cmd, display_cmd=verbose)
 
 
+
+
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def monitortx():
+    """show configurations of monitor tx"""
+    pass
+
+
+# show monitortx tx_config
+@monitortx.command()
+def tx_config():
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    data = config_db.get_table('TX_ERROR_CFG')
+
+    for param in data.keys():
+        value = data[param]['value']
+        if param.lower().endswith('period'):
+            conf = 'period_pool'
+        else:
+            conf = 'threshold'
+
+        click.echo('%s value is %s' % (conf, value))
+
+
+
+
+
 # 'counters' subcommand ("show interfaces counters")
 @interfaces.group(invoke_without_command=True)
 @click.option('-a', '--printall', is_flag=True)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did** : created additional commands in config and show folders

**- How I did it**: 

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

