### PR TITLE
[intfstat] Fix logic in RIF counters to print right stats

### DIFF
--- a/scripts/intfstat
+++ b/scripts/intfstat
@@ -204,17 +204,16 @@ class Intfstat(object):
 
         cntr = cnstat_new_dict.get(rif)
 
-        if cnstat_old_dict:
+        if cnstat_old_dict and cnstat_old_dict.get(rif):
             old_cntr = cnstat_old_dict.get(rif)
-            if old_cntr:
-                body = body % (ns_diff(cntr.rx_p_ok, old_cntr.rx_p_ok),
-                            ns_diff(cntr.rx_b_ok, old_cntr.rx_b_ok),
-                            ns_diff(cntr.rx_p_err, old_cntr.rx_p_err),
-                            ns_diff(cntr.rx_b_err, old_cntr.rx_b_err),
-                            ns_diff(cntr.tx_p_ok, old_cntr.tx_p_ok),
-                            ns_diff(cntr.tx_b_ok, old_cntr.tx_b_ok),
-                            ns_diff(cntr.tx_p_err, old_cntr.tx_p_err),
-                            ns_diff(cntr.tx_b_err, old_cntr.tx_b_err))
+            body = body % (ns_diff(cntr.rx_p_ok, old_cntr.rx_p_ok),
+                        ns_diff(cntr.rx_b_ok, old_cntr.rx_b_ok),
+                        ns_diff(cntr.rx_p_err, old_cntr.rx_p_err),
+                        ns_diff(cntr.rx_b_err, old_cntr.rx_b_err),
+                        ns_diff(cntr.tx_p_ok, old_cntr.tx_p_ok),
+                        ns_diff(cntr.tx_b_ok, old_cntr.tx_b_ok),
+                        ns_diff(cntr.tx_p_err, old_cntr.tx_p_err),
+                        ns_diff(cntr.tx_b_err, old_cntr.tx_b_err))
         else:
             body = body % (cntr.rx_p_ok, cntr.rx_b_ok, cntr.rx_p_err,cntr.rx_b_err,
                            cntr.tx_p_ok, cntr.tx_b_ok, cntr.tx_p_err, cntr.tx_b_err)
@@ -258,8 +257,9 @@ def main():
     wait_time_in_seconds = args.period
     interface_name = args.interface if args.interface else ""
 
-    # fancy filename with dashes: uid-tag-intf / uid-intf / uid-tag etc
-    filename_components = [uid, tag_name, interface_name]
+    # fancy filename with dashes: uid-tag / uid etc
+    filename_components = [uid, tag_name]
+
     cnstat_file = "-".join(filter(None, filename_components))
 
     cnstat_dir = "/tmp/intfstat-" + uid
@@ -305,7 +305,26 @@ def main():
 
     if save_fresh_stats:
         try:
-            pickle.dump(cnstat_dict, open(cnstat_fqn_file, 'wb'))
+            # Add the information also to the general file - i.e. without the tag name
+            if tag_name != '' and tag_name in cnstat_fqn_file.split('/')[-1]:
+                gen_index = cnstat_fqn_file.rfind('/')
+                cnstat_fqn_general_file = cnstat_fqn_file[:gen_index] + cnstat_fqn_file[gen_index:].split('-')[0]
+                if os.path.isfile(cnstat_fqn_general_file):
+                    try:
+                        general_data = pickle.load(open(cnstat_fqn_general_file, 'rb'))
+                        for key, val in cnstat_dict.items():
+                            general_data[key] = val
+                        pickle.dump(general_data, open(cnstat_fqn_general_file, 'wb'))
+                    except IOError as e:
+                        sys.exit(e.errno)
+            # Add the information also to tag specific file
+            if os.path.isfile(cnstat_fqn_file):
+                data = pickle.load(open(cnstat_fqn_file, 'rb'))
+                for key, val in cnstat_dict.items():
+                    data[key] = val
+                pickle.dump(data, open(cnstat_fqn_file, 'wb'))
+            else:
+                pickle.dump(cnstat_dict, open(cnstat_fqn_file, 'wb'))
         except IOError as e:
             sys.exit(e.errno)
         else:
@@ -313,9 +332,17 @@ def main():
             sys.exit(0)
 
     if wait_time_in_seconds == 0:
-        if os.path.isfile(cnstat_fqn_file):
+        gen_index = cnstat_fqn_file.rfind('/')
+        cnstat_fqn_general_file = cnstat_fqn_file[:gen_index] + cnstat_fqn_file[gen_index:].split('-')[0]
+
+        if os.path.isfile(cnstat_fqn_file) or (os.path.isfile(cnstat_fqn_general_file)):
             try:
-                cnstat_cached_dict = pickle.load(open(cnstat_fqn_file, 'rb'))
+                cnstat_cached_dict = {}
+                if os.path.isfile(cnstat_fqn_file):
+                    cnstat_cached_dict = pickle.load(open(cnstat_fqn_file, 'rb'))
+                else:
+                    cnstat_cached_dict = pickle.load(open(cnstat_fqn_general_file, 'rb'))
+
                 print("Last cached time was " + str(cnstat_cached_dict.get('time')))
                 if interface_name:
                     intfstat.cnstat_single_interface(interface_name, cnstat_dict, cnstat_cached_dict)

--- a/tests/intfstat_test.py
+++ b/tests/intfstat_test.py
@@ -103,6 +103,26 @@ class TestIntfstat(object):
         show.run_command("intfstat -D")
         assert expected in result.output
 
+    def test_clear_single_interface_check_all(self):
+        runner = CliRunner()
+        result = runner.invoke(clear.cli.commands["rifcounters"], ["Ethernet20"])
+        print(result.stdout)
+        assert result.exit_code == 0
+        result = runner.invoke(show.cli.commands["interfaces"].commands["counters"].commands["rif"], [])
+        print(result.stdout)
+        expected = ["     Ethernet20        0  0.00 B/s    0.00/s         0        0  0.00 B/s    0.00/s         0",
+                    "PortChannel0001      883       N/A       N/A         0        0       N/A       N/A         0",
+                    "PortChannel0002      883       N/A       N/A         0        0       N/A       N/A         0",
+                    "PortChannel0003        0       N/A       N/A         0        0       N/A       N/A         0",
+                    "PortChannel0004      883       N/A       N/A         0        0       N/A       N/A         0",
+                    "       Vlan1000        0       N/A       N/A         0        0       N/A       N/A         0"]
+
+
+        # remove the counters snapshot
+        show.run_command("intfstat -D")
+        for line in expected:
+            assert line in result.output
+
     def test_clear(self):
         runner = CliRunner()
         result = runner.invoke(clear.cli.commands["rifcounters"], [])


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix logic in scripts/intfstat file.
Before the change: 
If a user cleared all counters using `sonic-clear rifcounters` command and then queried for rif counters with a certain interface (e.g. `show interfaces counters rif Ethernet0`), the user would see the older stats. meaning the clear was not performed. 
The reason for this is that when we do sonic-clear rifcounters, the counters are not really being cleared, but current stats are saved into a file, and in the next counters query, it will calculate the diff between current counters and the saved counters. 
If the clear was performed in general (without an interface name), it's saved to a general file (e.g. 0). 
If the clear was performed for a certain interface, it's saved to an interface file (e.g. 0-Ethernet0).
so when we clear in one method and then query for the other, we can receive the info from the wrong file and display different stats. 

#### How I did it
Add the logic: 
when deleting for a certain interface, add the info to the general file. 
when querying for a certain interface, check the general file as well. 

#### How to verify it
* send traffic to interface
* check general rif table (`show interfaces counters rif`)
* clear general rifcounters (`sonic-clear rifcounters`)
* check that the specific interface table is also updated (`show interfaces counters rif Ethernet0`)

* send traffic to interface
* clear interface table (`sonic-clear rifcounters Ethernet0`)
* check that general table is updated as well (`show interfaces counters rif`)
#### Previous command output (if the output of a command-line utility has changed)
N/A
#### New command output (if the output of a command-line utility has changed)
N/A
