### PR TITLE
[202012] [generate_dump] allow to extend dump with plugin scripts

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -203,7 +203,7 @@ def watermark():
     """ Watermark counter commands """
 
 @watermark.command()
-@click.argument('poll_interval', type=click.IntRange(1000, 30000))
+@click.argument('poll_interval', type=click.IntRange(1000, 60000))
 def interval(poll_interval):
     """ Set watermark counter query interval for both queue and PG watermarks """
     configdb = swsssdk.ConfigDBConnector()

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -32,6 +32,7 @@ DUMPDIR=/var/dump
 TARDIR=$DUMPDIR/$BASE
 TARFILE=$DUMPDIR/$BASE.tar
 LOGDIR=$DUMPDIR/$BASE/dump
+PLUGINS_DIR=/usr/local/bin/debug-dump
 NUM_ASICS=1
 HOME=${HOME:-/root}
 USER=${USER:-root}
@@ -153,6 +154,7 @@ save_bcmcmd_all_ns() {
 #  filename: the filename to save the output as in $BASE/dump
 #  do_gzip: (OPTIONAL) true or false. Should the output be gzipped
 #  cleanup_method: (OPTIONAL) the cleanup method to procress dump file after it generated.
+#  save_stderr: (OPTIONAL) true or false. Should the stderr output be saved
 # Returns:
 #  None
 ###############################################################################
@@ -164,6 +166,7 @@ save_cmd() {
     local filename=$2
     local filepath="${LOGDIR}/$filename"
     local do_gzip=${3:-false}
+    local save_stderr=${4:-true}
     local tarpath="${BASE}/dump/$filename"
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
     local cleanup_method=${4:-dummy_cleanup_method}
@@ -181,6 +184,11 @@ save_cmd() {
 
     if [ ! -d $LOGDIR ]; then
         $MKDIR $V -p $LOGDIR
+    fi
+
+    if ! $save_stderr
+    then
+        redirect=">"
     fi
 
     # eval required here to re-evaluate the $cmd properly at runtime
@@ -839,7 +847,7 @@ collect_mellanox() {
         ${CMD_PREFIX}/usr/bin/mstdump /dev/mst/mt*conf0 > "${mst_dump_filename}${i}"
         save_file "${mst_dump_filename}${i}" mstdump true
     done
-    
+
     # Save SDK error dumps
     local sdk_dump_path=`${CMD_PREFIX}docker exec syncd cat /tmp/sai.profile|grep "SAI_DUMP_STORE_PATH"|cut -d = -f2`
     if [[ -d $sdk_dump_path ]]; then
@@ -1056,7 +1064,7 @@ save_crash_files() {
 get_asic_count() {
     trap 'handle_error $? $LINENO' ERR
     local redirect_eval="2>&1"
-    if ! $SAVE_STDERR 
+    if ! $SAVE_STDERR
     then
          redirect_eval=""
     fi
@@ -1216,6 +1224,12 @@ main() {
     save_cmd "docker ps -a" "docker.ps"
     save_cmd "docker top pmon" "docker.pmon"
 
+    local -r dump_plugins="$(find ${PLUGINS_DIR} -type f -executable)"
+    for plugin in $dump_plugins; do
+        # save stdout output of plugin and gzip it
+        save_cmd "$plugin" "$(basename $plugin)" true false
+    done
+
     save_saidump
 
     if [[ "$asic" = "mellanox" ]]; then
@@ -1298,7 +1312,7 @@ main() {
     fi
 
     echo ${TARFILE}
-    
+
     if ! $SAVE_STDERR
     then
     	exit $RETURN_CODE
@@ -1350,7 +1364,7 @@ remove_secret_from_etc_files() {
 
     # Remove snmp community string from snmp.yml
     sed -i -E 's/(\s*snmp_\S*community\s*:\s*)(\S*)/\1****/g' $dumppath/etc/sonic/snmp.yml
-    
+
     # Remove secret from /etc/sonic/config_db.json
     cat $dumppath/etc/sonic/config_db.json | remove_secret_from_config_db_dump > $dumppath/etc/sonic/config_db.json.temp
     mv $dumppath/etc/sonic/config_db.json.temp $dumppath/etc/sonic/config_db.json
@@ -1409,7 +1423,7 @@ OPTIONS
         "24 March", "yesterday", etc.
     -t TIMEOUT_MINS
         Command level timeout in minutes
-    -r 
+    -r
         Redirect any intermediate errors to STDERR
 
 EOF

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -152,6 +152,7 @@ save_bcmcmd_all_ns() {
 #  cmd: The command to run. Make sure that arguments with spaces have quotes
 #  filename: the filename to save the output as in $BASE/dump
 #  do_gzip: (OPTIONAL) true or false. Should the output be gzipped
+#  cleanup_method: (OPTIONAL) the cleanup method to procress dump file after it generated.
 # Returns:
 #  None
 ###############################################################################
@@ -165,6 +166,7 @@ save_cmd() {
     local do_gzip=${3:-false}
     local tarpath="${BASE}/dump/$filename"
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
+    local cleanup_method=${4:-dummy_cleanup_method}
     local redirect='&>'
     local redirect_eval='2>&1'
     if [ ! -d $LOGDIR ]; then
@@ -188,7 +190,9 @@ save_cmd() {
     if $do_gzip; then
         tarpath="${tarpath}.gz"
         filepath="${filepath}.gz"
-        local cmds="$cmd $redirect_eval | gzip -c > '${filepath}'"
+        # cleanup_method will run in a sub-shell, need declare it first
+        local cleanup_method_declration=$(declare -f $cleanup_method)
+        local cmds="$cleanup_method_declration; $cmd $redirect_eval | $cleanup_method | gzip -c > '${filepath}'"
         if $NOOP; then
             echo "${timeout_cmd} bash -c \"${cmds}\""
         else
@@ -200,10 +204,10 @@ save_cmd() {
         fi
     else
         if $NOOP; then
-            echo "${timeout_cmd} $cmd $redirect '$filepath'"
+            echo "${timeout_cmd} $cmd | $cleanup_method $redirect '$filepath'"
         else
             RC=0
-            eval "${timeout_cmd} $cmd" "$redirect" "$filepath" || RC=$?
+            eval "${timeout_cmd} $cmd | $cleanup_method" "$redirect" "$filepath" || RC=$?
             if [ $RC -ne 0 ]; then
                 echo "Command: $cmd timedout after ${TIMEOUT_MIN} minutes."
             fi
@@ -217,6 +221,19 @@ save_cmd() {
 }
 
 ###############################################################################
+# Dummy cleanup method.
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+dummy_cleanup_method() {
+    cat
+}
+
+###############################################################################
 # Runs a given command in all namesapces in case of multi ASIC platform, in
 # default (host) namespace in single ASIC platform
 # Globals:
@@ -225,22 +242,24 @@ save_cmd() {
 #  cmd: The command to run. Make sure that arguments with spaces have quotes
 #  filename: the filename to save the output as in $BASE/dump
 #  do_gzip: (OPTIONAL) true or false. Should the output be gzipped
+#  cleanup_method: (OPTIONAL) the cleanup method to procress dump file after it generated.
 # Returns:
 #  None
 ###############################################################################
 save_cmd_all_ns() {
     trap 'handle_error $? $LINENO' ERR
     local do_zip=${3:-false}
+    local cleanup_method=${4:-dummy_cleanup_method}
 
     # host or default namespace
-    save_cmd "$1" "$2" "$do_zip"
+    save_cmd "$1" "$2" "$do_zip" $cleanup_method
 
     if [[ ( "$NUM_ASICS" > 1 ) ]] ; then
       for (( i=0; i<$NUM_ASICS; i++ ))
       do
           local cmd="sonic-netns-exec asic$i $1"
           local file="$2.$i"
-          save_cmd "$cmd" "$file" "$do_zip"
+          save_cmd "$cmd" "$file" "$do_zip" $cleanup_method
       done
     fi
 }
@@ -592,7 +611,8 @@ save_redis_info() {
     save_redis "APPL_DB"
     save_redis "ASIC_DB"
     save_redis "COUNTERS_DB"
-    save_redis "CONFIG_DB"
+    # There are secrets in CONFIG_DB need to be cleanup.
+    save_redis "CONFIG_DB" "CONFIG_DB" remove_secret_from_config_db_dump
     save_redis "FLEX_COUNTER_DB"
     save_redis "STATE_DB"
 }
@@ -638,10 +658,12 @@ save_proc() {
 # Arguments:
 #  DB name: DB name
 #  Filename: Destination filename, if not given then filename would be DB name
+#  cleanup_method: (OPTIONAL) the cleanup method to procress dump file after it generated.
 # Returns:
 #  None
 ###############################################################################
 save_redis() {
+    local cleanup_method=${3:-dummy_cleanup_method}
     trap 'handle_error $? $LINENO' ERR
     local db_name=$1
     if [ $# -ge 2 ] && [ -n "$2" ]; then
@@ -649,7 +671,7 @@ save_redis() {
     else
         local dest_file_name="$db_name"
     fi
-    save_cmd_all_ns "sonic-db-dump -n '$db_name' -y" "$dest_file_name.json"
+    save_cmd_all_ns "sonic-db-dump -n '$db_name' -y" "$dest_file_name.json" false $cleanup_method
 }
 
 ###############################################################################
@@ -1218,6 +1240,9 @@ main() {
         rm $rm_list
     fi
 
+    # Remove secret from /etc files before tar
+    remove_secret_from_etc_files $TARDIR
+
     start_t=$(date +%s%3N)
     ($TAR $V --warning=no-file-removed -rhf $TARFILE -C $DUMPDIR --mode=+rw \
         --exclude="etc/alternatives" \
@@ -1230,6 +1255,13 @@ main() {
         --exclude="*snmpd.conf*" \
         --exclude="/etc/mlnx" \
         --exclude="/etc/mft" \
+        --exclude="*/etc/sonic/*.cer" \
+        --exclude="*/etc/sonic/*.crt" \
+        --exclude="*/etc/sonic/*.pem" \
+        --exclude="*/etc/sonic/*.key" \
+        --exclude="*/etc/ssl/*.pem" \
+        --exclude="*/etc/ssl/certs/*" \
+        --exclude="*/etc/ssl/private/*" \
         $BASE/etc \
         || abort "${ERROR_TAR_FAILED}" "Tar append operation failed. Aborting for safety.") \
         && $RM $V -rf $TARDIR
@@ -1271,6 +1303,57 @@ main() {
     then
     	exit $RETURN_CODE
     fi
+}
+
+###############################################################################
+# Remove secret from pipeline inout and output result to pipeline.
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  None
+###############################################################################
+remove_secret_from_config_db_dump() {
+    # Remove tacacs & radius passkey and snmp community from config DB
+    sed -E 's/\"passkey\"\s*:\s*\"([^\"]*)\"/\"passkey\":\"****\"/g; /SNMP_COMMUNITY/,/\s{2,4}\},/d'
+}
+
+###############################################################################
+# Remove secret from dump files.
+# Globals:
+# Arguments:
+#  dumppath: the dump file path.
+# Returns:
+#  None
+###############################################################################
+remove_secret_from_etc_files() {
+    local dumppath=$1
+    echo "Remove secret from etc files."
+    # Remove tacacs passkey from tacplus_nss.conf
+    local secret_regex='s/(secret=)([^,|\S]*)(.*)/\1****\3/g'
+    sed -i -E $secret_regex $dumppath/etc/tacplus_nss.conf
+
+    # Remove radius passkey from radius_nss.conf
+    sed -i -E $secret_regex $dumppath/etc/radius_nss.conf
+
+    # Remove tacacs passkey from common-auth-sonic
+    sed -i -E 's/(secret=)(\S*)/\1****/g' $dumppath/etc/pam.d/common-auth-sonic
+
+    # Remove tacacs passkey from pam_radius_auth.conf
+    sed -i -E 's/^([^#]\S*\s*)(\S*)/\1****/g' $dumppath/etc/pam_radius_auth.conf
+
+    # Remove radius passkey from per-server conf file /etc/pam_radius_auth.d/{ip}_{port}.conf
+    for filename in $dumppath/etc/pam_radius_auth.d/*.conf; do
+        sed -i -E 's/^([^#]\S*\s*)(\S*)/\1****/g' $filename
+    done
+
+    # Remove snmp community string from snmp.yml
+    sed -i -E 's/(\s*snmp_\S*community\s*:\s*)(\S*)/\1****/g' $dumppath/etc/sonic/snmp.yml
+    
+    # Remove secret from /etc/sonic/config_db.json
+    cat $dumppath/etc/sonic/config_db.json | remove_secret_from_config_db_dump > $dumppath/etc/sonic/config_db.json.temp
+    mv $dumppath/etc/sonic/config_db.json.temp $dumppath/etc/sonic/config_db.json
 }
 
 ###############################################################################

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -32,6 +32,7 @@ DUMPDIR=/var/dump
 TARDIR=$DUMPDIR/$BASE
 TARFILE=$DUMPDIR/$BASE.tar
 LOGDIR=$DUMPDIR/$BASE/dump
+PLUGINS_DIR=/usr/local/bin/debug-dump
 NUM_ASICS=1
 HOME=${HOME:-/root}
 USER=${USER:-root}
@@ -152,6 +153,7 @@ save_bcmcmd_all_ns() {
 #  cmd: The command to run. Make sure that arguments with spaces have quotes
 #  filename: the filename to save the output as in $BASE/dump
 #  do_gzip: (OPTIONAL) true or false. Should the output be gzipped
+#  save_stderr: (OPTIONAL) true or false. Should the stderr output be saved
 # Returns:
 #  None
 ###############################################################################
@@ -163,6 +165,7 @@ save_cmd() {
     local filename=$2
     local filepath="${LOGDIR}/$filename"
     local do_gzip=${3:-false}
+    local save_stderr=${4:-true}
     local tarpath="${BASE}/dump/$filename"
     local timeout_cmd="timeout --foreground ${TIMEOUT_MIN}m"
     local redirect='&>'
@@ -179,6 +182,11 @@ save_cmd() {
 
     if [ ! -d $LOGDIR ]; then
         $MKDIR $V -p $LOGDIR
+    fi
+
+    if ! $save_stderr
+    then
+        redirect=">"
     fi
 
     # eval required here to re-evaluate the $cmd properly at runtime
@@ -817,7 +825,7 @@ collect_mellanox() {
         ${CMD_PREFIX}/usr/bin/mstdump /dev/mst/mt*conf0 > "${mst_dump_filename}${i}"
         save_file "${mst_dump_filename}${i}" mstdump true
     done
-    
+
     # Save SDK error dumps
     local sdk_dump_path=`${CMD_PREFIX}docker exec syncd cat /tmp/sai.profile|grep "SAI_DUMP_STORE_PATH"|cut -d = -f2`
     if [[ -d $sdk_dump_path ]]; then
@@ -1034,7 +1042,7 @@ save_crash_files() {
 get_asic_count() {
     trap 'handle_error $? $LINENO' ERR
     local redirect_eval="2>&1"
-    if ! $SAVE_STDERR 
+    if ! $SAVE_STDERR
     then
          redirect_eval=""
     fi
@@ -1194,6 +1202,12 @@ main() {
     save_cmd "docker ps -a" "docker.ps"
     save_cmd "docker top pmon" "docker.pmon"
 
+    local -r dump_plugins="$(find ${PLUGINS_DIR} -type f -executable)"
+    for plugin in $dump_plugins; do
+        # save stdout output of plugin and gzip it
+        save_cmd "$plugin" "$(basename $plugin)" true false
+    done
+
     save_saidump
 
     if [[ "$asic" = "mellanox" ]]; then
@@ -1266,7 +1280,7 @@ main() {
     fi
 
     echo ${TARFILE}
-    
+
     if ! $SAVE_STDERR
     then
     	exit $RETURN_CODE
@@ -1326,7 +1340,7 @@ OPTIONS
         "24 March", "yesterday", etc.
     -t TIMEOUT_MINS
         Command level timeout in minutes
-    -r 
+    -r
         Redirect any intermediate errors to STDERR
 
 EOF


### PR DESCRIPTION
Signed-off-by: Noa Or <noaor@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added support for tech support extension scripts,
by cherry-picking of https://github.com/Azure/sonic-utilities/pull/1335 to branch 202012

The purpose is to have dumps of extensions in SONiC techsupport, even without App Extension infrastructure.
The new application will write a file that contains the dump command into /usr/bin/debug-dump folder, and it will appear in the output of `show techsupport` command.
#### How I did it
It looks at /usr/bin/debug-dump for scripts, if it finds one it will execute them and save the output to dump/ folder.

#### How to verify it
Write a simple scripts that outputs something and place it under /usr/bin/debug-dump/

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

