### PR TITLE
[Mellanox] Fix generate_dump sysfs copy to copy only files with permission

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -932,7 +932,7 @@ save_sdk_sysfs() {
         return 1
     }
 
-    copy_file() {
+    copy_file_content() {
         local f="$1"
         local target="$2"
         if $NOOP; then
@@ -947,7 +947,7 @@ save_sdk_sysfs() {
         if [[ -f "$f" ]]; then
             local base="$(basename "$f")"
             should_skip "$base" && continue
-            copy_file "$f" "$dest/$base"
+            copy_file_content "$f" "$dest/$base"
         fi
     done
 
@@ -980,7 +980,7 @@ save_sdk_sysfs() {
                     [[ "$only_copy_presence_files" == true && "$base" != "present" && "$base" != "hw_present" ]] && continue
                     [[ "$frequency_support" == "0" && "$base" == "frequency" ]] && continue
 
-                    copy_file "$f" "$subdir_dest/$base"
+                    copy_file_content "$f" "$subdir_dest/$base"
                 fi
             done
         fi

--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -914,7 +914,7 @@ save_sys() {
     chmod ugo+rw -R $DUMPDIR/$BASE/sys
 }
 
-save_sysfs() {
+save_sdk_sysfs() {
     trap 'handle_error $? $LINENO' ERR
     local src="$1"
     local dest="$2"
@@ -932,39 +932,55 @@ save_sysfs() {
         return 1
     }
 
+    copy_file() {
+        local f="$1"
+        local target="$2"
+        if $NOOP; then
+            echo "cat $f > $target 2>/dev/null"
+        else
+            cat "$f" > "$target" 2>/dev/null
+        fi
+    }
+
     # Copy files directly under src
     for f in "$src"/*; do
-        if [ -f "$f" ]; then
+        if [[ -f "$f" ]]; then
             local base="$(basename "$f")"
             should_skip "$base" && continue
-            local target="$dest/$base"
-
-            if $NOOP; then
-                echo "cat $f > $target 2>/dev/null"
-            else
-                cat "$f" > "$target" 2>/dev/null
-            fi
+            copy_file "$f" "$dest/$base"
         fi
     done
 
     # Copy sub folders
     for d in "$src"/*; do
-        if [ -d "$d" ]; then
+        if [[ -d "$d" ]]; then
             local subdir_dest="$dest/$(basename "$d")"
             $MKDIR $V -p "$subdir_dest"
 
+            local present=0 hw_present="" frequency_support=0 only_copy_presence_files=false
+            [[ -f "$d/present" ]] && present=$(<"$d/present")
+            [[ -f "$d/hw_present" ]] && hw_present=$(<"$d/hw_present")
+            [[ -f "$d/frequency_support" ]] && frequency_support=$(<"$d/frequency_support")
+
+            # if the module is unplugged, skip the rest of the files
+            if [[ -n "$hw_present" ]]; then
+                if [[ "$present" == "0" && "$hw_present" == "0" ]]; then
+                    only_copy_presence_files=true
+                fi
+            else
+                [[ "$present" == "0" ]] && only_copy_presence_files=true
+            fi
+
             # copy only files inside sub folder, not sub-sub folders
             for f in "$d"/*; do
-                if [ -f "$f" ]; then
+                if [[ -f "$f" ]]; then
                     local base="$(basename "$f")"
                     should_skip "$base" && continue
-                    local target="$subdir_dest/$base"
 
-                    if $NOOP; then
-                        echo "cat $f > $target 2>/dev/null"
-                    else
-                        cat "$f" > "$target" 2>/dev/null
-                    fi
+                    [[ "$only_copy_presence_files" == true && "$base" != "present" && "$base" != "hw_present" ]] && continue
+                    [[ "$frequency_support" == "0" && "$base" == "frequency" ]] && continue
+
+                    copy_file "$f" "$subdir_dest/$base"
                 fi
             done
         fi
@@ -1491,7 +1507,7 @@ collect_mellanox() {
     local sdk_sysfs_dest_path="$TARDIR/sdk_sysfs/sx_core/asic0"
     local excludes_sysfs_files=(rx_los tx_disable module_info module_latched_flag_info power_mode power_mode_policy reinsert reset)
 
-    save_sysfs "$sdk_sysfs_src_path" "$sdk_sysfs_dest_path" "${excludes_sysfs_files[@]}" &
+    save_sdk_sysfs "$sdk_sysfs_src_path" "$sdk_sysfs_dest_path" "${excludes_sysfs_files[@]}" &
 
     # Save CMIS-host-management related files
     local cmis_host_mgmt_path="cmis-host-mgmt"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix generate dump script to only copy valid files: 
- If the module is not present, copy only presence files. 
error: ERR kernel: sxd_kernel: [error] show_module_frequency: __sx_core_get_module_frequency failed (-14) for module64
- If frequency_support value is 0, don't copy frequency sysfs
error: ERR kernel: [  858.655221] sxd_kernel: [error] __sx_core_get_module_frequency: Frequency read is not supported.
#### How I did it
check the above files content before copying all
#### How to verify it
run 'show techsupport' on Nvidia switch and validate output
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

