### PR TITLE
[Mellanox] Add restricted sysfs list for fw control modules

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -921,14 +921,19 @@ save_sdk_sysfs() {
     shift 2
     # sys files we do not want to include in dump
     local excludes=("$@")
-
+    # there are module's sysfs which we cannot access while the module is in fw control
+    local fw_control_skip_list=(frequency_support frequency hw_present hw_reset low_power_mode power_good power_limit)
     $MKDIR $V -p "$dest"
 
     should_skip() {
         local base="$1"
-        for ex in "${excludes[@]}"; do
-            [[ "$base" == "$ex" ]] && return 0
+        shift
+        local skip_list=("$@")
+
+        for skip in "${skip_list[@]}"; do
+            [[ "$base" == "$skip" ]] && return 0
         done
+
         return 1
     }
 
@@ -946,7 +951,7 @@ save_sdk_sysfs() {
     for f in "$src"/*; do
         if [[ -f "$f" ]]; then
             local base="$(basename "$f")"
-            should_skip "$base" && continue
+            should_skip "$base" "${excludes[@]}" && continue
             copy_file_content "$f" "$dest/$base"
         fi
     done
@@ -957,10 +962,12 @@ save_sdk_sysfs() {
             local subdir_dest="$dest/$(basename "$d")"
             $MKDIR $V -p "$subdir_dest"
 
-            local present=0 hw_present="" frequency_support=0 only_copy_presence_files=false
+            local present=0 hw_present="" control="" frequency_support=0 only_copy_presence_files=false
+            [[ -f "$d/control" ]] && control=$(<"$d/control")
             [[ -f "$d/present" ]] && present=$(<"$d/present")
             [[ -f "$d/hw_present" ]] && hw_present=$(<"$d/hw_present")
-            [[ -f "$d/frequency_support" ]] && frequency_support=$(<"$d/frequency_support")
+            # frequency_support is supported only for SW control modules
+            [[ "$control" == "1" && -f "$d/frequency_support" ]] && frequency_support=$(<"$d/frequency_support")
 
             # if the module is unplugged, skip the rest of the files
             if [[ -n "$hw_present" ]]; then
@@ -975,7 +982,8 @@ save_sdk_sysfs() {
             for f in "$d"/*; do
                 if [[ -f "$f" ]]; then
                     local base="$(basename "$f")"
-                    should_skip "$base" && continue
+                    should_skip "$base" "${excludes[@]}" && continue
+                    [[ "$control" == "0" ]] && should_skip "$base" "${fw_control_skip_list[@]}" && continue
 
                     [[ "$only_copy_presence_files" == true && "$base" != "present" && "$base" != "hw_present" ]] && continue
                     [[ "$frequency_support" == "0" && "$base" == "frequency" ]] && continue


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added a restricted list for FW control modules. 
If control == 0, do not copy them to dump as we have no access for them.
#### How I did it
Update Mellanox code in generate_dump script
#### How to verify it
take dump (show techsupport) in sonic. check that for FW controlled ports, we copy only allowed sysfs.
#### Previous command output (if the output of a command-line utility has changed)
N/A
#### New command output (if the output of a command-line utility has changed)
N/A
