### PR TITLE
[Mellanox] Add restricted sysfs to fw control list

### DIFF
--- a/scripts/generate_dump
+++ b/scripts/generate_dump
@@ -922,7 +922,8 @@ save_sdk_sysfs() {
     # sys files we do not want to include in dump
     local excludes=("$@")
     # there are module's sysfs which we cannot access while the module is in fw control
-    local fw_control_skip_list=(frequency_support frequency hw_present hw_reset low_power_mode power_good power_limit)
+    local fw_control_skip_list=(frequency_support frequency hw_present hw_reset low_power_mode power_good power_limit interrupt)
+
     $MKDIR $V -p "$dest"
 
     should_skip() {
@@ -965,7 +966,8 @@ save_sdk_sysfs() {
             local present=0 hw_present="" control="" frequency_support=0 only_copy_presence_files=false
             [[ -f "$d/control" ]] && control=$(<"$d/control")
             [[ -f "$d/present" ]] && present=$(<"$d/present")
-            [[ -f "$d/hw_present" ]] && hw_present=$(<"$d/hw_present")
+            # hw_present is supported only for SW control modules
+            [[ "$control" == "1" && -f "$d/hw_present" ]] && hw_present=$(<"$d/hw_present")
             # frequency_support is supported only for SW control modules
             [[ "$control" == "1" && -f "$d/frequency_support" ]] && frequency_support=$(<"$d/frequency_support")
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add interrupt sysfs to restricted fw control sysfs list, and took hw_present value only if control == 1.
#### How I did it
Updated generate_dump script
#### How to verify it
run show techsupport on switch
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

